### PR TITLE
Bad enum property name

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/AnySchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/AnySchema.java
@@ -24,7 +24,7 @@ public class AnySchema extends SimpleTypeSchema {
 	   of enum values uses the same algorithm as defined in "uniqueItems"
 	   (Section 5.15).
 	 */
-	@JsonProperty
+	@JsonProperty(value = "enum")
 	private Set<String> enums;
 	
 	@JsonIgnore

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ContainerTypeSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ContainerTypeSchema.java
@@ -22,7 +22,7 @@ public abstract class ContainerTypeSchema extends SimpleTypeSchema {
 	   of enum values uses the same algorithm as defined in "uniqueItems"
 	   (Section 5.15).
 	 */
-	@JsonProperty(required = true)
+	@JsonProperty(value = "enum", required = true)
 	private Set<String> enums;
 	
 	//instance initializer block 

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ValueTypeSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ValueTypeSchema.java
@@ -22,7 +22,7 @@ public abstract class ValueTypeSchema extends SimpleTypeSchema {
 	   of enum values uses the same algorithm as defined in "uniqueItems"
 	   (Section 5.15).
 	 */
-	@JsonProperty
+	@JsonProperty(value = "enum")
 	private Set<String> enums = new HashSet<String>();
 	
 	/**

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -269,7 +269,7 @@ public class TestGenerateJsonSchema
                     new HashMap<String,Object>(){{ put("letter", 
                             new HashMap<String,Object>() {{
                                 put("type", "string");
-                                put("enums", new ArrayList<String>() {{
+                                put("enum", new ArrayList<String>() {{
                                     add("A"); add("B"); add("C");
                                 }} );
                             }} );


### PR DESCRIPTION
Issue #7

Regarding the last JSON Schema specification, the enum validation property must be named 'enum' instead of 'enums'.

The enum property is declared here : http://json-schema.org/latest/json-schema-validation.html#anchor76.
