### PR TITLE
Support enriching schema objects with property-specific information of a bean

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
@@ -459,6 +460,15 @@ public abstract class JsonSchema {
 
 	public void setRequired(Boolean required) {
 		this.required = required;
+	}
+
+	/**
+	 * Override this to add information specific to the property of bean
+	 * For example, bean validation annotations could be used to specify
+	 * value constraints in the schema
+	 * @param beanProperty
+	 */
+	public void enrichWithBeanProperty(BeanProperty beanProperty) {
 	}
 
 	/**

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ObjectVisitor.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ObjectVisitor.java
@@ -57,7 +57,7 @@ public class ObjectVisitor extends JsonObjectFormatVisitor.Base
     
     @Override
     public void optionalProperty(BeanProperty prop) throws JsonMappingException {
-        schema.putOptionalProperty(prop.getName(), propertySchema(prop));
+        schema.putOptionalProperty(prop, propertySchema(prop));
     }
 	
     @Override
@@ -68,7 +68,7 @@ public class ObjectVisitor extends JsonObjectFormatVisitor.Base
 
     @Override
     public void property(BeanProperty prop) throws JsonMappingException {
-        schema.putProperty(prop.getName(), propertySchema(prop));
+        schema.putProperty(prop, propertySchema(prop));
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ObjectSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ObjectSchema.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 
@@ -140,12 +141,23 @@ public class ObjectSchema extends ContainerTypeSchema {
 		return true;
 	}
 
+	public void putOptionalProperty(BeanProperty property, JsonSchema jsonSchema) {
+		jsonSchema.enrichWithBeanProperty(property);
+		properties.put(property.getName(), jsonSchema);
+	}
+	
 	public void putOptionalProperty(String name, JsonSchema jsonSchema) {
 		properties.put(name, jsonSchema);
 	}
 
 	public JsonSchema putPatternProperty(String regex, JsonSchema value) {
 		return patternProperties.put(regex, value);
+	}
+	
+	public JsonSchema putProperty(BeanProperty property, JsonSchema value) {
+		value.setRequired(true);
+		value.enrichWithBeanProperty(property);
+		return properties.put(property.getName(), value);		
 	}
 
 	public JsonSchema putProperty(String name, JsonSchema value) {


### PR DESCRIPTION
With this added functionality, the following becomes possible:

``` java
import javax.validation.constraints.Min;
import com.fasterxml.jackson.databind.BeanProperty;
import com.fasterxml.jackson.module.jsonSchema.types.IntegerSchema;

public class CrudIntegerSchema extends IntegerSchema {

    @Override
    public void enrichWithBeanProperty(BeanProperty beanProperty) {
        Min minimum = beanProperty.getAnnotation(Min.class);
        if (minimum != null) {
            this.setMinimum((double)minimum.value());
        }

    }
}
```

Bean validation, documentation strings, and custom schema annotation support become achievable.

This resolves https://github.com/FasterXML/jackson-module-jsonSchema/issues/18
