### PR TITLE
Easier customization of SchemaFactoryWrapper

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchemaGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchemaGenerator.java
@@ -1,8 +1,10 @@
 package com.fasterxml.jackson.module.jsonSchema;
 
-import com.fasterxml.jackson.databind.*;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
+import com.fasterxml.jackson.module.jsonSchema.factories.WrapperFactory;
 
 /**
  * Convenience class that wraps JSON Schema generation functionality.
@@ -13,20 +15,27 @@ public class JsonSchemaGenerator
 {
     protected final ObjectMapper _mapper;
     
+	private final WrapperFactory _wrapperFactory;
+    
     public JsonSchemaGenerator(ObjectMapper mapper) {
+        this(mapper, null);
+    }
+    
+    public JsonSchemaGenerator(ObjectMapper mapper, WrapperFactory wrapperFactory) {
         _mapper = mapper;
+    	_wrapperFactory = wrapperFactory == null ? new WrapperFactory() : wrapperFactory;
     }
 
     public JsonSchema generateSchema(Class<?> type) throws JsonMappingException
     {
-        SchemaFactoryWrapper visitor = new SchemaFactoryWrapper(null);
+        SchemaFactoryWrapper visitor = _wrapperFactory.getWrapper(_mapper == null ? null : _mapper.getSerializerProvider());
         _mapper.acceptJsonFormatVisitor(type, visitor);
         return visitor.finalSchema();
     }
 
     public JsonSchema generateSchema(JavaType type) throws JsonMappingException
     {
-        SchemaFactoryWrapper visitor = new SchemaFactoryWrapper(null);
+        SchemaFactoryWrapper visitor = _wrapperFactory.getWrapper(_mapper == null ? null : _mapper.getSerializerProvider());
         _mapper.acceptJsonFormatVisitor(type, visitor);
         return visitor.finalSchema();
     }

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/TitleSchemaFactoryWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/TitleSchemaFactoryWrapper.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.module.jsonSchema.factories.WrapperFactory;
  */
 public class TitleSchemaFactoryWrapper extends SchemaFactoryWrapper
 {
-    private WrapperFactory wrapperFactory = new WrapperFactory() {
+    private static class TitleSchemaFactoryWrapperFactory extends WrapperFactory {
 	    @Override
 	    public SchemaFactoryWrapper getWrapper(SerializerProvider p) {
 	        SchemaFactoryWrapper wrapper = new TitleSchemaFactoryWrapper();
@@ -27,10 +27,13 @@ public class TitleSchemaFactoryWrapper extends SchemaFactoryWrapper
 	    };
     };
 
+	public TitleSchemaFactoryWrapper() {
+		super(new TitleSchemaFactoryWrapperFactory());
+	}
+
     @Override
     public JsonObjectFormatVisitor expectObjectFormat(JavaType convertedType) {
 		ObjectVisitor visitor = ((ObjectVisitor)super.expectObjectFormat(convertedType));
-		visitor.setWrapperFactory(wrapperFactory);
 		
 		// could add other properties here
 		addTitle(visitor.getSchema(), convertedType);
@@ -41,7 +44,6 @@ public class TitleSchemaFactoryWrapper extends SchemaFactoryWrapper
     @Override
     public JsonArrayFormatVisitor expectArrayFormat(JavaType convertedType) {
 		ArrayVisitor visitor = ((ArrayVisitor)super.expectArrayFormat(convertedType));
-		visitor.setWrapperFactory(wrapperFactory);
 		
 		// could add other properties here
 		addTitle(visitor.getSchema(), convertedType);

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ArrayVisitor.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ArrayVisitor.java
@@ -17,8 +17,13 @@ public class ArrayVisitor extends JsonArrayFormatVisitor.Base
     private WrapperFactory wrapperFactory = new WrapperFactory();
 
     public ArrayVisitor(SerializerProvider provider, ArraySchema schema) {
+        this(provider, schema, new WrapperFactory());
+    }
+    
+    public ArrayVisitor(SerializerProvider provider, ArraySchema schema, WrapperFactory wrapperFactory) {
         this.provider = provider;
         this.schema = schema;
+        this.wrapperFactory = wrapperFactory;
     }
     
     /*

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/FormatVisitorFactory.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/FormatVisitorFactory.java
@@ -9,11 +9,19 @@ import com.fasterxml.jackson.module.jsonSchema.types.*;
  * Factory class used for constructing visitors for building various
  * JSON Schema instances via visitor interface.
  */
-public class FormatVisitorFactory
-{		
-    public FormatVisitorFactory() { }
+public class FormatVisitorFactory {
 
-    /*
+    private final WrapperFactory wrapperFactory;
+
+    public FormatVisitorFactory() {
+        this(new WrapperFactory());
+    }
+
+    public FormatVisitorFactory(WrapperFactory wrapperFactory) {
+        this.wrapperFactory = wrapperFactory;
+    }
+
+	/*
     /**********************************************************
     /* Factory methods for visitors, structured types
     /**********************************************************
@@ -25,17 +33,17 @@ public class FormatVisitorFactory
 
     public JsonArrayFormatVisitor arrayFormatVisitor(SerializerProvider provider,
             ArraySchema arraySchema) {
-        return new ArrayVisitor(provider, arraySchema);
+        return new ArrayVisitor(provider, arraySchema, wrapperFactory);
     }
 
     public JsonMapFormatVisitor mapFormatVisitor(SerializerProvider provider,
             ObjectSchema objectSchema) {
-        return new MapVisitor(provider, objectSchema);
+        return new MapVisitor(provider, objectSchema, wrapperFactory);
     }
 
     public JsonObjectFormatVisitor objectFormatVisitor(SerializerProvider provider,
             ObjectSchema objectSchema) {
-        return new ObjectVisitor(provider, objectSchema);
+        return new ObjectVisitor(provider, objectSchema, wrapperFactory);
     }
     
     /*

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/MapVisitor.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/MapVisitor.java
@@ -19,13 +19,17 @@ public class MapVisitor extends JsonMapFormatVisitor.Base
     protected final ObjectSchema schema;
 
     protected SerializerProvider provider;
+
+    private WrapperFactory wrapperFactory;
+
+    public MapVisitor(SerializerProvider provider, ObjectSchema schema) {
+        this(provider, schema, new WrapperFactory());
+    }
     
-    private WrapperFactory wrapperFactory = new WrapperFactory();
-    
-    public MapVisitor(SerializerProvider provider, ObjectSchema schema)
-    {
+    public MapVisitor(SerializerProvider provider, ObjectSchema schema, WrapperFactory wrapperFactory) {
         this.provider = provider;
         this.schema = schema;
+        this.wrapperFactory = wrapperFactory;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ObjectVisitor.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/ObjectVisitor.java
@@ -13,11 +13,16 @@ public class ObjectVisitor extends JsonObjectFormatVisitor.Base
     protected final ObjectSchema schema;
     protected SerializerProvider provider;
 
-    private WrapperFactory wrapperFactory = new WrapperFactory();
-    
+    private WrapperFactory wrapperFactory;
+
     public ObjectVisitor(SerializerProvider provider, ObjectSchema schema) {
+        this(provider, schema, new WrapperFactory());
+    }
+    
+    public ObjectVisitor(SerializerProvider provider, ObjectSchema schema, WrapperFactory wrapperFactory) {
         this.provider = provider;
         this.schema = schema;
+        this.wrapperFactory = wrapperFactory;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/SchemaFactoryWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/factories/SchemaFactoryWrapper.java
@@ -20,13 +20,21 @@ public class SchemaFactoryWrapper implements JsonFormatVisitorWrapper
     protected JsonSchema schema;
 
     public SchemaFactoryWrapper() {
-        this(null);
+        this(null, null);
     }
     
     public SchemaFactoryWrapper(SerializerProvider p) {
+        this(p, null);
+    }
+    
+    protected SchemaFactoryWrapper(WrapperFactory wrapperFactory) {
+        this(null, wrapperFactory);
+    }
+    
+    protected SchemaFactoryWrapper(SerializerProvider p, WrapperFactory wrapperFactory) {
         provider = p;
         schemaProvider = new JsonSchemaFactory();
-        visitorFactory = new FormatVisitorFactory();
+        visitorFactory = new FormatVisitorFactory(wrapperFactory == null ? new WrapperFactory() : wrapperFactory);
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TitleSchemaFactoryWrapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TitleSchemaFactoryWrapperTest.java
@@ -31,7 +31,7 @@ public class TitleSchemaFactoryWrapperTest extends TestCase{
 		JsonSchema schema2 = schema.asObjectSchema().getProperties().get("pet");
 		assertTrue("schema should be an objectSchema.", schema2.isObjectSchema());
 		String title2 = schema2.asObjectSchema().getTitle();
-		assertNotNull(title);
+		assertNotNull(title2);
 		assertTrue("schema should have a title", title2.indexOf("Pet") != -1);
 	}
 }


### PR DESCRIPTION
Hello,

It seems that SchemaFactoryWrapper was designed to allow customization. This patch makes it easier to customize the SchemaFactoryWrapper:
- the JsonSchemaGenerator constructors may now take a WrapperFactory as an argument, so that it can be used with subclasses of SchemaFactoryWrapper
- the FormatVisitorFactory now allows to define the WrapperFactory that will be assigned to visitors of structured schemas (object, array, map)
- consequently, the constructors of visitors of structured schemas (ObjectSchemaVisitor, ArraySchemaVisitor, MapSchemaVisitor) may now take a WrapperFactory as an argument.

I tried to keep changes to a minimum. This patch does not break the API and should not change the operation of current code based on the API. In fact, it merely adds new constructors.

Note : I also fixed a typo in a test (TitleSchemaFactoryWrapperTest.java). I noticed it while tweaking this patch.
