### PR TITLE
Add support for @Pattern annotations in String schemas

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
@@ -81,6 +81,7 @@ public class ValidationSchemaFactoryWrapper extends SchemaFactoryWrapper {
             StringSchema stringSchema = schema.asStringSchema();
             stringSchema.setMaxLength(constraintResolver.getStringMaxLength(prop));
             stringSchema.setMinLength(constraintResolver.getStringMinLength(prop));
+            stringSchema.setPattern(constraintResolver.getStringPattern(prop));
         }
         return schema;
     }

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/validation/AnnotationConstraintResolver.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/validation/AnnotationConstraintResolver.java
@@ -63,4 +63,13 @@ public class AnnotationConstraintResolver implements ValidationConstraintResolve
     public Integer getStringMinLength(BeanProperty prop) {
         return getMinSize(prop);
     }
+
+    @Override
+    public String getStringPattern(final BeanProperty prop) {
+        Pattern patternAnnotation = prop.getAnnotation(Pattern.class);
+        if (patternAnnotation != null) {
+            return patternAnnotation.regexp();
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/validation/ValidationConstraintResolver.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/validation/ValidationConstraintResolver.java
@@ -19,4 +19,5 @@ public interface ValidationConstraintResolver {
 
     Integer getStringMinLength(BeanProperty prop);
 
+    String getStringPattern(BeanProperty prop);
 }

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
@@ -87,6 +87,9 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
         @Size(min = 15, max = 16)
         private String stringWithMinAndMaxSize;
 
+        @Pattern(regexp = "[a-z]+")
+        private String stringWithPattern;
+
         public List<String> getListWithoutConstraints() {
             return listWithoutConstraints;
         }
@@ -222,6 +225,14 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
         public void setStringWithMinAndMaxSize(String stringWithMinAndMaxSize) {
             this.stringWithMinAndMaxSize = stringWithMinAndMaxSize;
         }
+
+        public String getStringWithPattern() {
+            return stringWithPattern;
+        }
+
+        public void setStringWithPattern(final String stringWithPattern) {
+            this.stringWithPattern = stringWithPattern;
+        }
     }
 
     /*
@@ -254,6 +265,11 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
                 {"stringWithMinSize", 13, null},
                 {"stringWithMaxSize", null, 14},
                 {"stringWithMinAndMaxSize", 15, 16}};
+    }
+
+    private Object[][] stringPatternTestData() {
+        return new Object[][] {{"stringWithPattern", "[a-z]+"},
+                {"stringWithoutConstraints", null}};
     }
 
     /**
@@ -293,6 +309,13 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
             StringSchema stringSchema = propertySchema.asStringSchema();
             assertEquals(testCase[1], stringSchema.getMinLength());
             assertEquals(testCase[2], stringSchema.getMaxLength());
+        }
+        for (Object[] testCase : stringPatternTestData()) {
+            JsonSchema propertySchema = properties.get(testCase[0]);
+            assertNotNull(propertySchema);
+            assertTrue(propertySchema.isStringSchema());
+            StringSchema stringSchema = propertySchema.asStringSchema();
+            assertEquals(testCase[1], stringSchema.getPattern());
         }
     }
 


### PR DESCRIPTION
Updated the `ValidationSchemaFactoryWrapper` to support the `@Pattern` annotation in addition to the other JSR 303 annotations it already supported