### PR TITLE
Fix typos in JsonSchema's methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
@@ -186,10 +186,20 @@ public abstract class JsonSchema
 	}
 
 	/**
+	 * @deprecated Since 2.7
+	 */
+	@Deprecated
+	public ContainerTypeSchema asContainerSchema() {
+		return asContainerTypeSchema();
+	}
+
+	/**
 	 * Attempt to return this JsonSchema as a {@link ContainerTypeSchema}
 	 * @return this as an ContainerTypeSchema if possible, or null otherwise
+	 *
+	 * @since 2.7
 	 */
-	public ContainerTypeSchema asContainerSchema() {
+	public ContainerTypeSchema asContainerTypeSchema() {
 		return null;
 	}
 
@@ -250,10 +260,20 @@ public abstract class JsonSchema
 	}
 
 	/**
+	 * @deprecated Since 2.7
+	 */
+	@Deprecated
+	public ValueTypeSchema asValueSchemaSchema() {
+		return asValueTypeSchema();
+	}
+
+	/**
 	 * Attempt to return this JsonSchema as a {@link ValueTypeSchema}
 	 * @return this as a ValueTypeSchema if possible, or null otherwise
+	 *
+	 * @since 2.7
 	 */
-	public ValueTypeSchema asValueSchemaSchema() {
+	public ValueTypeSchema asValueTypeSchema() {
 		return null;
 	}
 

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ContainerTypeSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ContainerTypeSchema.java
@@ -37,8 +37,20 @@ public abstract class ContainerTypeSchema extends SimpleTypeSchema
 	@JsonProperty(value = "oneOf", required = true)
 	protected Set<Object> oneOf = Collections.emptySet();
 
+	/**
+	 * @deprecated Since 2.7
+	 */
+	@Deprecated
 	@Override
-	public ContainerTypeSchema asContainerSchema() { return this; }
+	public ContainerTypeSchema asContainerSchema() {
+		return asContainerTypeSchema();
+	}
+
+	/**
+	 * @since 2.7
+	 */
+	@Override
+	public ContainerTypeSchema asContainerTypeSchema() { return this; }
 
 	public Set<String> getEnums() {
 	    return enums;

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ValueTypeSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ValueTypeSchema.java
@@ -39,8 +39,20 @@ public abstract class ValueTypeSchema extends SimpleTypeSchema
 	@JsonProperty
 	protected JsonValueFormat format;
 
+	/**
+	 * @deprecated Since 2.7
+	 */
+	@Deprecated
 	@Override
-	public ValueTypeSchema asValueSchemaSchema() { return this; }
+	public ValueTypeSchema asValueSchemaSchema() {
+		return asValueTypeSchema();
+	}
+
+	/**
+	 * @since 2.7
+	 */
+	@Override
+	public ValueTypeSchema asValueTypeSchema() { return this; }
 
 	public Set<String> getEnums() {
 	    return enums;


### PR DESCRIPTION
- asContainerSchema -> asContainerTypeSchema
- asValueSchemaSchema -> asValueTypeSchema

The old methods are marked as deprecated.