### PR TITLE
Use BigDecimal instead of Double in NumberFormat

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
 import com.fasterxml.jackson.module.jsonSchema.validation.AnnotationConstraintResolver;
 import com.fasterxml.jackson.module.jsonSchema.validation.ValidationConstraintResolver;
 
+import java.math.BigDecimal;
+
 /**
  * @author cponomaryov
  */
@@ -75,8 +77,10 @@ public class ValidationSchemaFactoryWrapper extends SchemaFactoryWrapper {
             arraySchema.setMinItems(constraintResolver.getArrayMinItems(prop));
         } else if (schema.isNumberSchema()) {
             NumberSchema numberSchema = schema.asNumberSchema();
-            numberSchema.setMaximum(constraintResolver.getNumberMaximum(prop));
-            numberSchema.setMinimum(constraintResolver.getNumberMinimum(prop));
+            Double max = constraintResolver.getNumberMaximum(prop);
+            numberSchema.setMaximum(maybeBigDecimal(max));
+            Double min = constraintResolver.getNumberMinimum(prop);
+            numberSchema.setMinimum(maybeBigDecimal(min));
         } else if (schema.isStringSchema()) {
             StringSchema stringSchema = schema.asStringSchema();
             stringSchema.setMaxLength(constraintResolver.getStringMaxLength(prop));
@@ -84,6 +88,13 @@ public class ValidationSchemaFactoryWrapper extends SchemaFactoryWrapper {
             stringSchema.setPattern(constraintResolver.getStringPattern(prop));
         }
         return schema;
+    }
+
+    private BigDecimal maybeBigDecimal(Double value) {
+        if (value == null)
+            return null;
+        else
+            return new BigDecimal(value);
     }
 
 }

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 
+import java.math.BigDecimal;
+
 /**
  * This class represents a {@link JsonSchema} as a number type
  * @author jphelan
@@ -28,15 +30,15 @@ public class NumberSchema extends ValueTypeSchema
 	
 	/**This attribute defines the maximum value of the instance property*/
 	@JsonProperty
-	private Double maximum = null;
+	private BigDecimal maximum = null;
 
 	/**This attribute defines the minimum value of the instance property*/
 	@JsonProperty
-	private Double minimum = null;
+	private BigDecimal minimum = null;
 
 	/** The value of the instance needs to be a multiple of this attribute */
 	@JsonProperty
-	private Double multipleOf = null;
+	private BigDecimal multipleOf = null;
 
 	@Override
 	public NumberSchema asNumberSchema() { return this; }
@@ -49,15 +51,15 @@ public class NumberSchema extends ValueTypeSchema
 		return exclusiveMinimum;
 	}
 
-	public Double getMaximum() {
+	public BigDecimal getMaximum() {
 		return maximum;
 	}
 
-	public Double getMinimum() {
+	public BigDecimal getMinimum() {
 		return minimum;
 	}
 
-	public Double getMultipleOf() {
+	public BigDecimal getMultipleOf() {
 		return multipleOf;
 	}
 	
@@ -81,15 +83,15 @@ public class NumberSchema extends ValueTypeSchema
 	    this.exclusiveMinimum = exclusiveMinimum;
 	}
 
-	public void setMaximum(Double maximum) {
+	public void setMaximum(BigDecimal maximum) {
 	    this.maximum = maximum;
 	}
 
-	public void setMinimum(Double minimum) {
+	public void setMinimum(BigDecimal minimum) {
 	    this.minimum = minimum;
 	}
 
-	public void setMultipleOf(Double multipleOf) {
+	public void setMultipleOf(BigDecimal multipleOf) {
 		this.multipleOf = multipleOf;
 	}
 

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
@@ -29,10 +29,14 @@ public class NumberSchema extends ValueTypeSchema
 	/**This attribute defines the maximum value of the instance property*/
 	@JsonProperty
 	private Double maximum = null;
-	
+
 	/**This attribute defines the minimum value of the instance property*/
 	@JsonProperty
 	private Double minimum = null;
+
+	/** The value of the instance needs to be a multiple of this attribute */
+	@JsonProperty
+	private Double multipleOf = null;
 
 	@Override
 	public NumberSchema asNumberSchema() { return this; }
@@ -51,6 +55,10 @@ public class NumberSchema extends ValueTypeSchema
 
 	public Double getMinimum() {
 		return minimum;
+	}
+
+	public Double getMultipleOf() {
+		return multipleOf;
 	}
 	
 	/* (non-Javadoc)
@@ -81,6 +89,10 @@ public class NumberSchema extends ValueTypeSchema
 	    this.minimum = minimum;
 	}
 
+	public void setMultipleOf(Double multipleOf) {
+		this.multipleOf = multipleOf;
+	}
+
      @Override
      public boolean equals(Object obj)
      {
@@ -97,6 +109,5 @@ public class NumberSchema extends ValueTypeSchema
                  equals(getMaximum(), that.getMaximum()) &&
                  equals(getMinimum(), that.getMinimum()) &&
                  super._equals(that);
-     } 
-
+     }
 }

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/NumberSchema.java
@@ -108,6 +108,7 @@ public class NumberSchema extends ValueTypeSchema
                  equals(getExclusiveMinimum(), that.getExclusiveMinimum()) &&
                  equals(getMaximum(), that.getMaximum()) &&
                  equals(getMinimum(), that.getMinimum()) &&
+                 equals(getMultipleOf(), that.getMultipleOf()) &&
                  super._equals(that);
      }
 }

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.NumberSchema;
 import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
 
 import javax.validation.constraints.*;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -250,14 +251,14 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
 
     private Object[][] numberTestData() {
         return new Object[][] {{"numberWithoutConstraints", null, null},
-                {"numberWithMin", 5d, null},
-                {"numberWithDecimalMin", 5.5, null},
-                {"numberWithMax", null, 6d},
-                {"numberWithDecimalMax", null, 6.5},
-                {"numberWithMinAndMax", 7d, 8d},
-                {"numberWithMinAndDecimalMax", 9d, 9.5},
-                {"numberWithDecimalMinAndMax", 10.5, 11d},
-                {"numberWithDecimalMinAndDecimalMax", 11.5, 12.5}};
+                {"numberWithMin", new BigDecimal(5d), null},
+                {"numberWithDecimalMin", new BigDecimal(5.5), null},
+                {"numberWithMax", null, new BigDecimal(6d)},
+                {"numberWithDecimalMax", null, new BigDecimal(6.5)},
+                {"numberWithMinAndMax", new BigDecimal(7d), new BigDecimal(8d)},
+                {"numberWithMinAndDecimalMax", new BigDecimal(9d), new BigDecimal(9.5)},
+                {"numberWithDecimalMinAndMax", new BigDecimal(10.5), new BigDecimal(11d)},
+                {"numberWithDecimalMinAndDecimalMax", new BigDecimal(11.5), new BigDecimal(12.5)}};
     }
 
     private Object[][] stringTestData() {


### PR DESCRIPTION
JSON can have number values outside the range of double. Also, it's important that multipleOf have an exact representation to be interpreted correctly. BigDecimal is better for these reasons.