### PR TITLE
Changing "required" from boolean to array as per specification

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
 import com.fasterxml.jackson.module.jsonSchema.types.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * The type wraps the json schema specification at :
  * <a href="http://tools.ietf.org/id/draft-zyp-json-schema-03.txt"> Json JsonSchema
@@ -142,11 +145,12 @@ public abstract class JsonSchema
 	private JsonSchema[] extendsextends;
 
 	/**
-	 * This attribute indicates if the instance must have a value, and not be
-	 * undefined. This is false by default, making the instance optional.
+	 * This attribute enumerates names of child properties that must have a value,
+	 * and not be undefined.
+	 * This is null by default, making all child properties optional.
 	 */
 	@JsonProperty
-	private Boolean required = null;
+	private List<String> required = null;
 
     /**
      * This attribute indicates if the instance is not modifiable.
@@ -299,7 +303,7 @@ public abstract class JsonSchema
 		return extendsextends;
 	}
 
-	public Boolean getRequired() {
+	public List<String> getRequired() {
 		return required;
 	}
 
@@ -455,8 +459,15 @@ public abstract class JsonSchema
 		this.id = id;
 	}
 
-	public void setRequired(Boolean required) {
+	public void setRequired(List<String> required) {
 		this.required = required;
+	}
+
+	public void addRequired(String required) {
+		if (this.required == null) {
+			this.required = new ArrayList<>();
+		}
+		this.required.add(required);
 	}
 
     public void setReadonly(Boolean readonly){

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/customProperties/ValidationSchemaFactoryWrapper.java
@@ -57,22 +57,22 @@ public class ValidationSchemaFactoryWrapper extends SchemaFactoryWrapper {
             @Override
             public void optionalProperty(BeanProperty writer) throws JsonMappingException {
                 super.optionalProperty(writer);
-                addValidationConstraints(getPropertySchema(writer), writer);
+                addValidationConstraints(getPropertySchema(writer), getSchema(), writer);
             }
 
             @Override
             public void property(BeanProperty writer) throws JsonMappingException {
                 super.property(writer);
-                addValidationConstraints(getPropertySchema(writer), writer);
+                addValidationConstraints(getPropertySchema(writer), getSchema(), writer);
             }
         };
     }
 
-    protected JsonSchema addValidationConstraints(JsonSchema schema, BeanProperty prop) {
+    protected JsonSchema addValidationConstraints(JsonSchema schema, JsonSchema parentSchema, BeanProperty prop) {
         {
             Boolean required = constraintResolver.getRequired(prop);
-            if (required != null) {
-                schema.setRequired(required);
+            if (Boolean.TRUE.equals(required)) {
+                parentSchema.addRequired(prop.getName());
             }
         }
         if (schema.isArraySchema()) {

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ObjectSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/ObjectSchema.java
@@ -126,13 +126,13 @@ public class ObjectSchema extends ContainerTypeSchema
 	}
 	
 	public JsonSchema putProperty(BeanProperty property, JsonSchema value) {
-		value.setRequired(true);
+		addRequired(property.getName());
 		value.enrichWithBeanProperty(property);
 		return properties.put(property.getName(), value);		
 	}
 
 	public JsonSchema putProperty(String name, JsonSchema value) {
-		value.setRequired(true);
+		addRequired(name);
 		return properties.put(name, value);
 	}
 

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/CustomSchemaReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/CustomSchemaReadTest.java
@@ -42,7 +42,7 @@ public class CustomSchemaReadTest extends SchemaTestBase
     // [module-jsonSchema#67]
     public void testSchema() throws Exception
     {
-         String input = "{ \"type\" : \"CUSTOM\" , \"id\" : \"7a2e8538-196b-423e-b714-13515848ec0c\" , \"description\" : \"My Schema\" , \"title\" : \"my-json-schema\" , \"properties\" : { \"myarray\" : { \"type\" : \"array\" , \"required\" : true , \"title\" : \"my property #2\" , \"items\" : { \"type\" : \"string\"} , \"maxItems\" : 5} , \"mystring\" : { \"type\" : \"string\" , \"required\" : true , \"title\" : \"my property #1\" , \"format\" : \"regex\" , \"pattern\" : \"\\\\w+\"} , \"myobject\" : { \"type\" : \"object\" , \"required\" : true , \"title\" : \"my property #3\" , \"properties\" : { \"subprop\" : { \"type\" : \"string\" , \"required\" : true , \"title\" : \"sub property #1\" , \"format\" : \"regex\" , \"pattern\" : \"\\\\w{3}\"}}}}}";
+         String input = "{ \"type\" : \"CUSTOM\" , \"id\" : \"7a2e8538-196b-423e-b714-13515848ec0c\" , \"description\" : \"My Schema\" , \"title\" : \"my-json-schema\" , \"required\" : [\"myarray\", \"mystring\", \"myobject\"] , \"properties\" : { \"myarray\" : { \"type\" : \"array\" , \"title\" : \"my property #2\" , \"items\" : { \"type\" : \"string\"} , \"maxItems\" : 5} , \"mystring\" : { \"type\" : \"string\" , \"title\" : \"my property #1\" , \"format\" : \"regex\" , \"pattern\" : \"\\\\w+\"} , \"myobject\" : { \"type\" : \"object\" , \"title\" : \"my property #3\" , \"required\" : [\"subprop\"] , \"properties\" : { \"subprop\" : { \"type\" : \"string\" , \"title\" : \"sub property #1\" , \"format\" : \"regex\" , \"pattern\" : \"\\\\w{3}\"}}}}}";
 
          ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -173,7 +173,7 @@ public class TestGenerateJsonSchema
 
         JsonSchema prop5 = properties.get("property5");
         assertNotNull(prop5);
-        assertTrue(prop5.getRequired());
+        assertEquals(Collections.singletonList("property5"), object.getRequired());
         assertNull(prop5.getReadonly());
 
     }
@@ -207,7 +207,7 @@ public class TestGenerateJsonSchema
         // no need to check out full structure, just basics...
         assertEquals("object", result.get("type"));
         // only add 'required' if it is true...
-        assertNull(result.get("required"));
+        assertEquals(Collections.singletonList("property5"), result.get("required"));
         assertNotNull(result.get("properties"));
     }
 

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/ValidationSchemaFactoryWrapperTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.NumberSchema;
 import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
 
 import javax.validation.constraints.*;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -299,10 +300,10 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
                 {"stringWithoutConstraints", null}};
     }
 
-    private Object[][] notNullTestData() {
-        return new Object[][] {
-                {"nullable", null},
-                {"notNullable", true}};
+    private Object[][] requiredData() {
+        return new Object[][]{
+                {Collections.singletonList("notNullable")}
+        };
     }
 
     /**
@@ -350,10 +351,9 @@ public class ValidationSchemaFactoryWrapperTest extends SchemaTestBase {
             StringSchema stringSchema = propertySchema.asStringSchema();
             assertEquals(testCase[1], stringSchema.getPattern());
         }
-        for (Object[] testCase : notNullTestData()) {
-            JsonSchema propertySchema = properties.get(testCase[0]);
-            assertNotNull(propertySchema);
-            assertEquals(testCase[1], propertySchema.getRequired());
+        for (Object[] testCase : requiredData()) {
+            List<String> required = jsonSchema.getRequired();
+            assertEquals(testCase[0], required);
         }
     }
 


### PR DESCRIPTION
As per [specification](http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3) field "required" must be an array of child properties that are mandatory, not a boolean.

I am not sure why we ended up with it being boolean in the first place.
However, we should address this issue, because generated schema can not be used with other tools as it violates the spec.

I understand that this change is backward-incompatible, so it should be targeted for 2.8.