### PR TITLE
Deserialize empty JSON schemas

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
@@ -69,7 +69,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.*;
  * @author jphelan
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonTypeInfo(use = Id.CUSTOM, include = As.PROPERTY, property = "type")
+@JsonTypeInfo(use = Id.CUSTOM, include = As.PROPERTY, property = "type", defaultImpl = AnySchema.class)
 @JsonTypeIdResolver(JsonSchemaIdResolver.class)
 public abstract class JsonSchema
 {

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/NoTypeSchemaReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/NoTypeSchemaReadTest.java
@@ -1,0 +1,52 @@
+package com.fasterxml.jackson.module.jsonSchema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+
+public class NoTypeSchemaReadTest extends SchemaTestBase {
+    public void testNoTypeSchema() throws Exception {
+        String input = "{}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonSchema schema = mapper.readValue(input, JsonSchema.class);
+
+        assertEquals(JsonFormatTypes.ANY, schema.getType());
+    }
+
+    public void testNoTypeSingleItems() throws Exception {
+        String input = "{ \"type\": \"array\", \"items\": {} }";
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonSchema schema = mapper.readValue(input, JsonSchema.class);
+
+        assertTrue(schema instanceof ArraySchema);
+
+        ArraySchema.Items items = ((ArraySchema) schema).getItems();
+        assertNotNull(items);
+        assertTrue(items.isSingleItems());
+
+        JsonSchema itemsSchema = items.asSingleItems().getSchema();
+        assertNotNull(itemsSchema);
+        assertEquals(JsonFormatTypes.ANY, itemsSchema.getType());
+    }
+
+    public void testNoTypeArrayItems() throws Exception {
+        String input = "{ \"type\": \"array\", \"items\": [{}] }";
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonSchema schema = mapper.readValue(input, JsonSchema.class);
+
+        assertTrue(schema instanceof ArraySchema);
+
+        ArraySchema.Items items = ((ArraySchema) schema).getItems();
+        assertNotNull(items);
+        assertTrue(items.isArrayItems());
+
+        JsonSchema[] itemsSchemas = items.asArrayItems().getJsonSchemas();
+        assertNotNull(itemsSchemas);
+        assertEquals(itemsSchemas.length, 1);
+        assertNotNull(itemsSchemas[0]);
+        assertEquals(JsonFormatTypes.ANY, itemsSchemas[0].getType());
+    }
+}


### PR DESCRIPTION
### Affects: [2.8.2](https://github.com/FasterXML/jackson-module-jsonSchema/tree/jackson-module-jsonSchema-2.8.2)
### Issue
### [Spec pointer](https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1)

> If the property is not defined or is not in this list, then any
>       type of value is acceptable.

I'd expect an empty JSON schema to be deserialized as `AnySchema`.
### How to reproduce
#### POM file

``` xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>fr.quilicicf.test</groupId>
    <artifactId>jackson-module-jsonSchema</artifactId>
    <version>0.0.1-SNAPSHOT</version>

    <dependencies>
        <dependency>
            <groupId>com.fasterxml.jackson.module</groupId>
            <artifactId>jackson-module-jsonSchema</artifactId>
            <version>2.8.2</version>
        </dependency>

        <dependency>
            <groupId>junit</groupId>
            <artifactId>junit</artifactId>
            <version>4.12</version>
        </dependency>
    </dependencies>
</project>
```
#### Java file

``` java
package fr.quilicicf.test;

import org.junit.Assert;
import org.junit.Test;

import com.fasterxml.jackson.databind.ObjectMapper;
import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
import com.fasterxml.jackson.module.jsonSchema.types.AnySchema;

public class JsonSchemaDeserialization {

    @Test
    public void test() throws Exception {
        JsonSchema jsonSchema = new ObjectMapper().readValue("{}", JsonSchema.class);
        Assert.assertTrue(jsonSchema instanceof AnySchema);
    }
}
```
#### Trace

```
com.fasterxml.jackson.databind.JsonMappingException: Unexpected token (END_OBJECT), expected FIELD_NAME: missing property 'type' that is to contain type id  (for class com.fasterxml.jackson.module.jsonSchema.JsonSchema)
 at [Source: {}; line: 1, column: 2]
    at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:261)
    at com.fasterxml.jackson.databind.DeserializationContext.wrongTokenException(DeserializationContext.java:1340)
    at com.fasterxml.jackson.databind.DeserializationContext.reportWrongTokenException(DeserializationContext.java:1196)
    at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer._deserializeTypedUsingDefaultImpl(AsPropertyTypeDeserializer.java:157)
    at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer.deserializeTypedFromObject(AsPropertyTypeDeserializer.java:105)
    at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserializeWithType(AbstractDeserializer.java:142)
    at com.fasterxml.jackson.databind.deser.impl.TypeWrappedDeserializer.deserialize(TypeWrappedDeserializer.java:63)
    at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3789)
    at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2833)
    at fr.quilicicf.test.JsonSchemaDeserialization.test(JsonSchemaDeserialization.java:23)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
```
