### PR TITLE
Feature/mediatype

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/StringSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/StringSchema.java
@@ -26,6 +26,12 @@ public class StringSchema extends ValueTypeSchema {
 	@JsonProperty
 	private String pattern;
 
+        /**
+         * The will be the media type
+         */
+        @JsonProperty
+        private String mediaType;
+        
 	@Override
 	public StringSchema asStringSchema() {
 		return this;
@@ -43,6 +49,10 @@ public class StringSchema extends ValueTypeSchema {
 	    return pattern;
 	}
 
+        public String getMediaType() {
+            return mediaType;
+        }
+        
 	@Override
 	public JsonFormatTypes getType() {
 	    return JsonFormatTypes.STRING;
@@ -65,6 +75,10 @@ public class StringSchema extends ValueTypeSchema {
 	    this.pattern = pattern;
 	}
 
+        public void setMediaType(String mediaType) {
+            this.mediaType = mediaType;
+        }
+        
      @Override
      public boolean equals(Object obj)
      {

--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/StringSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/types/StringSchema.java
@@ -27,7 +27,7 @@ public class StringSchema extends ValueTypeSchema {
 	private String pattern;
 
         /**
-         * The will be the media type
+         * This will be the media type
          */
         @JsonProperty
         private String mediaType;


### PR DESCRIPTION
Changes to add mediatype to the StringSchema according to json schema 0.3.
Media type is specified in the schema but previously there was no way to set the media type on a StringSchema.  