### PR TITLE
fixed id comparison in _equals

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
+++ b/src/main/java/com/fasterxml/jackson/module/jsonSchema/JsonSchema.java
@@ -518,7 +518,7 @@ public abstract class JsonSchema
 
     protected boolean _equals(JsonSchema that)
     {
-        return equals(getId(), getId())
+        return equals(getId(), that.getId())
                  // 27-Apr-2015, tatu: Should not need to check type explicitly
  //                 && equals(getType(), getType())
                 && equals(getRequired(), that.getRequired())


### PR DESCRIPTION
I think the protected boolean _equals(JsonSchema that) contains an issue on the 'id' comparison line. It should be equals(getId(), that.getId()) instead of the current code that is  equals(getId(), getId()).